### PR TITLE
Server package rename and testing

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/MattSScott/basePlatformSOMAS/pkg/main/server"
+	baseserver "github.com/MattSScott/basePlatformSOMAS/pkg/main/BaseServer"
 	"github.com/MattSScott/basePlatformSOMAS/pkg/testing/testAgents/baseExtendedAgent"
 	helloagent "github.com/MattSScott/basePlatformSOMAS/pkg/testing/testAgents/helloAgent"
 	worldagent "github.com/MattSScott/basePlatformSOMAS/pkg/testing/testAgents/worldAgent"
@@ -10,10 +10,10 @@ import (
 
 func main() {
 
-	m := make([]server.AgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent], 5)
+	m := make([]baseserver.AgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent], 2)
 
-	m[0] = server.MakeAgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent](helloagent.GetHelloAgent, 3)
-	m[1] = server.MakeAgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent](worldagent.GetWorldAgent, 2)
+	m[0] = baseserver.MakeAgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent](helloagent.GetHelloAgent, 3)
+	m[1] = baseserver.MakeAgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent](worldagent.GetWorldAgent, 2)
 
 	iterations := 1
 	ts := testserver.New(m, iterations)

--- a/pkg/main/BaseAgent/agentInterface.go
+++ b/pkg/main/BaseAgent/agentInterface.go
@@ -6,11 +6,22 @@ import (
 	"github.com/google/uuid"
 )
 
+type INetwork[T any] interface {
+	// returns the full agent network map
+	GetNetwork() map[uuid.UUID]T
+	// adds an agent object to the network
+	AddAgentToNetwork(agent T)
+	// removes an agent object from the network
+	RemoveAgentFromNetwork(agent T)
+}
+
 type IAgent[T any] interface {
 	// composes messaging passing capabilities
 	message.IAgentMessenger[T]
-	// allows agent to update their internal state
-	UpdateAgentInternalState()
+	// handles network operations
+	INetwork[T]
 	// returns the unique ID of an agent
 	GetID() uuid.UUID
+	// allows agent to update their internal state
+	UpdateAgentInternalState()
 }

--- a/pkg/main/BaseAgent/agentInterface.go
+++ b/pkg/main/BaseAgent/agentInterface.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/uuid"
 )
 
-type INetwork[T any] interface {
+type IAgentNetworking[T any] interface {
 	// returns the full agent network map
 	GetNetwork() map[uuid.UUID]T
 	// adds an agent object to the network
@@ -19,7 +19,7 @@ type IAgent[T any] interface {
 	// composes messaging passing capabilities
 	message.IAgentMessenger[T]
 	// handles network operations
-	INetwork[T]
+	IAgentNetworking[T]
 	// returns the unique ID of an agent
 	GetID() uuid.UUID
 	// allows agent to update their internal state

--- a/pkg/main/BaseAgent/agentInterface.go
+++ b/pkg/main/BaseAgent/agentInterface.go
@@ -6,20 +6,9 @@ import (
 	"github.com/google/uuid"
 )
 
-type IAgentNetworking[T any] interface {
-	// returns the full agent network map
-	GetNetwork() map[uuid.UUID]T
-	// adds an agent object to the network
-	AddAgentToNetwork(agent T)
-	// removes an agent object from the network
-	RemoveAgentFromNetwork(agent T)
-}
-
 type IAgent[T any] interface {
 	// composes messaging passing capabilities
 	message.IAgentMessenger[T]
-	// handles network operations
-	IAgentNetworking[T]
 	// returns the unique ID of an agent
 	GetID() uuid.UUID
 	// allows agent to update their internal state

--- a/pkg/main/BaseAgent/baseAgent.go
+++ b/pkg/main/BaseAgent/baseAgent.go
@@ -7,30 +7,35 @@ import (
 
 type BaseAgent[T IAgent[T]] struct {
 	id      uuid.UUID
-	network []T
+	network map[uuid.UUID]T
 }
 
 func (ba *BaseAgent[T]) GetID() uuid.UUID {
 	return ba.id
 }
 
-func (ba *BaseAgent[T]) UpdateAgentInternalState() {
-}
+func (ba *BaseAgent[T]) UpdateAgentInternalState() {}
 
 func NewAgent[T IAgent[T]]() *BaseAgent[T] {
 	return &BaseAgent[T]{
-		id: uuid.New(),
+		id:      uuid.New(),
+		network: make(map[uuid.UUID]T),
 	}
 }
 
-func (ba *BaseAgent[T]) GetAllMessages() []message.IMessage[T] {
+func (ba *BaseAgent[T]) GetAllMessages(listOfAgents []T) []message.IMessage[T] {
+
 	return []message.IMessage[T]{}
 }
 
-func (ba *BaseAgent[T]) GetNetwork() []T {
+func (ba *BaseAgent[T]) GetNetwork() map[uuid.UUID]T {
 	return ba.network
 }
 
-func (ba *BaseAgent[T]) SetNetwork(newNetwork []T) {
-	ba.network = newNetwork
+func (ba *BaseAgent[T]) AddAgentToNetwork(agent T) {
+	ba.network[agent.GetID()] = agent
+}
+
+func (ba *BaseAgent[T]) RemoveAgentFromNetwork(agent T) {
+	delete(ba.network, agent.GetID())
 }

--- a/pkg/main/BaseAgent/baseAgent.go
+++ b/pkg/main/BaseAgent/baseAgent.go
@@ -6,8 +6,7 @@ import (
 )
 
 type BaseAgent[T IAgent[T]] struct {
-	id      uuid.UUID
-	network map[uuid.UUID]T
+	id uuid.UUID
 }
 
 func (ba *BaseAgent[T]) GetID() uuid.UUID {
@@ -18,31 +17,11 @@ func (ba *BaseAgent[T]) UpdateAgentInternalState() {}
 
 func NewAgent[T IAgent[T]]() *BaseAgent[T] {
 	return &BaseAgent[T]{
-		id:      uuid.New(),
-		network: make(map[uuid.UUID]T),
-	}
-}
-
-func DefaultAgent[T IAgent[T]]() IAgent[T] {
-	return &BaseAgent[T]{
-		id:      uuid.New(),
-		network: make(map[uuid.UUID]T),
+		id: uuid.New(),
 	}
 }
 
 func (ba *BaseAgent[T]) GetAllMessages(listOfAgents []T) []message.IMessage[T] {
 
 	return []message.IMessage[T]{}
-}
-
-func (ba *BaseAgent[T]) GetNetwork() map[uuid.UUID]T {
-	return ba.network
-}
-
-func (ba *BaseAgent[T]) AddAgentToNetwork(agent T) {
-	ba.network[agent.GetID()] = agent
-}
-
-func (ba *BaseAgent[T]) RemoveAgentFromNetwork(agent T) {
-	delete(ba.network, agent.GetID())
 }

--- a/pkg/main/BaseAgent/baseAgent.go
+++ b/pkg/main/BaseAgent/baseAgent.go
@@ -23,6 +23,13 @@ func NewAgent[T IAgent[T]]() *BaseAgent[T] {
 	}
 }
 
+func DefaultAgent[T IAgent[T]]() IAgent[T] {
+	return &BaseAgent[T]{
+		id:      uuid.New(),
+		network: make(map[uuid.UUID]T),
+	}
+}
+
 func (ba *BaseAgent[T]) GetAllMessages(listOfAgents []T) []message.IMessage[T] {
 
 	return []message.IMessage[T]{}

--- a/pkg/main/BaseAgent/baseAgent_test.go
+++ b/pkg/main/BaseAgent/baseAgent_test.go
@@ -11,34 +11,11 @@ type IBaseAgent interface {
 	baseagent.IAgent[IBaseAgent]
 }
 
-func TestAgentIDOperations(t *testing.T) {
+func TestAgentIdOperations(t *testing.T) {
 	baseAgent := baseagent.NewAgent[IBaseAgent]()
 
 	if baseAgent.GetID() == uuid.Nil {
 		t.Error("Agent not instantiated with valid ID")
-	}
-}
-
-func TestAddToNetwork(t *testing.T) {
-	agent1 := baseagent.NewAgent[IBaseAgent]()
-	agent2 := baseagent.NewAgent[IBaseAgent]()
-
-	agent1.AddAgentToNetwork(agent2)
-
-	if len(agent1.GetNetwork()) != 1 {
-		t.Error("Agent not correctly added to map")
-	}
-}
-
-func TestRemoveFromNetwork(t *testing.T) {
-	agent1 := baseagent.NewAgent[IBaseAgent]()
-	agent2 := baseagent.NewAgent[IBaseAgent]()
-
-	agent1.AddAgentToNetwork(agent2)
-	agent1.RemoveAgentFromNetwork(agent2)
-
-	if len(agent1.GetNetwork()) != 0 {
-		t.Error("Agent not correctly removed from map")
 	}
 }
 

--- a/pkg/main/BaseAgent/baseAgent_test.go
+++ b/pkg/main/BaseAgent/baseAgent_test.go
@@ -1,0 +1,81 @@
+package baseagent_test
+
+import (
+	"testing"
+
+	baseagent "github.com/MattSScott/basePlatformSOMAS/pkg/main/BaseAgent"
+	"github.com/google/uuid"
+)
+
+type IBaseAgent interface {
+	baseagent.IAgent[IBaseAgent]
+}
+
+func TestAgentIDOperations(t *testing.T) {
+	baseAgent := baseagent.NewAgent[IBaseAgent]()
+
+	if baseAgent.GetID() == uuid.Nil {
+		t.Error("Agent not instantiated with valid ID")
+	}
+}
+
+func TestAddToNetwork(t *testing.T) {
+	agent1 := baseagent.NewAgent[IBaseAgent]()
+	agent2 := baseagent.NewAgent[IBaseAgent]()
+
+	agent1.AddAgentToNetwork(agent2)
+
+	if len(agent1.GetNetwork()) != 1 {
+		t.Error("Agent not correctly added to map")
+	}
+}
+
+func TestRemoveFromNetwork(t *testing.T) {
+	agent1 := baseagent.NewAgent[IBaseAgent]()
+	agent2 := baseagent.NewAgent[IBaseAgent]()
+
+	agent1.AddAgentToNetwork(agent2)
+	agent1.RemoveAgentFromNetwork(agent2)
+
+	if len(agent1.GetNetwork()) != 0 {
+		t.Error("Agent not correctly removed from map")
+	}
+}
+
+type AgentWithState struct {
+	*baseagent.BaseAgent[*AgentWithState]
+	state int
+}
+
+func (aws *AgentWithState) UpdateAgentInternalState() {
+	aws.state += 1
+}
+
+func TestUpdateAgentInternalState(t *testing.T) {
+	ag := AgentWithState{
+		baseagent.NewAgent[*AgentWithState](),
+		0,
+	}
+
+	if ag.state != 0 {
+		t.Error("Additional agent field not correctly instantiated")
+	}
+
+	ag.UpdateAgentInternalState()
+
+	if ag.state != 1 {
+		t.Error("Agent state not correctly updated")
+	}
+}
+
+func TestMessageRetrieval(t *testing.T) {
+
+	agent := baseagent.NewAgent[IBaseAgent]()
+
+	messages := agent.GetAllMessages([]IBaseAgent{agent})
+
+	if len(messages) > 0 {
+		t.Error("Agent erroneously constructed message")
+	}
+
+}

--- a/pkg/main/BaseServer/baseServer.go
+++ b/pkg/main/BaseServer/baseServer.go
@@ -1,4 +1,4 @@
-package server
+package baseserver
 
 import (
 	"fmt"

--- a/pkg/main/BaseServer/baseServer_test.go
+++ b/pkg/main/BaseServer/baseServer_test.go
@@ -1,0 +1,91 @@
+package baseserver_test
+
+import (
+	"testing"
+
+	baseagent "github.com/MattSScott/basePlatformSOMAS/pkg/main/BaseAgent"
+	baseserver "github.com/MattSScott/basePlatformSOMAS/pkg/main/BaseServer"
+)
+
+type ITestBaseAgent interface {
+	baseagent.IAgent[ITestBaseAgent]
+}
+
+type TestBaseAgent struct {
+	*baseagent.BaseAgent[ITestBaseAgent]
+}
+
+func NewTestBaseAgent() ITestBaseAgent {
+	return &TestBaseAgent{
+		baseagent.NewAgent[ITestBaseAgent](),
+	}
+}
+
+func TestAgentsCorrectlyInstantiated(t *testing.T) {
+	m := make([]baseserver.AgentGeneratorCountPair[ITestBaseAgent], 1)
+	m[0] = baseserver.MakeAgentGeneratorCountPair[ITestBaseAgent](NewTestBaseAgent, 3)
+
+	server := baseserver.CreateServer[ITestBaseAgent](m, 1)
+
+	if len(server.GetAgents()) != 3 {
+		t.Error("Incorrect number of agents added to server")
+	}
+
+}
+
+func TestNumTurnsInServer(t *testing.T) {
+	m := make([]baseserver.AgentGeneratorCountPair[ITestBaseAgent], 1)
+	m[0] = baseserver.MakeAgentGeneratorCountPair[ITestBaseAgent](NewTestBaseAgent, 3)
+
+	server := baseserver.CreateServer[ITestBaseAgent](m, 1)
+
+	if server.GetNumTurns() != 1 {
+		t.Error("Incorrect number of turns instantiated")
+	}
+
+}
+
+type IExtendedTestServer interface {
+	baseserver.IServer[ITestBaseAgent]
+	GetAdditionalField() int
+}
+
+type ExtendedTestServer struct {
+	*baseserver.BaseServer[ITestBaseAgent]
+	testField int
+}
+
+func (ets *ExtendedTestServer) GetAdditionalField() int {
+	return ets.testField
+}
+
+func (ets *ExtendedTestServer) RunGameLoop() {
+
+	ets.BaseServer.RunGameLoop()
+	ets.testField += 1
+}
+
+func CreateTestServer(mapper []baseserver.AgentGeneratorCountPair[ITestBaseAgent], iters int) IExtendedTestServer {
+	return &ExtendedTestServer{
+		BaseServer: baseserver.CreateServer[ITestBaseAgent](mapper, iters),
+		testField:  0,
+	}
+}
+
+func TestServerGameLoop(t *testing.T) {
+	m := make([]baseserver.AgentGeneratorCountPair[ITestBaseAgent], 1)
+	m[0] = baseserver.MakeAgentGeneratorCountPair[ITestBaseAgent](NewTestBaseAgent, 3)
+
+	server := CreateTestServer(m, 1)
+
+	if server.GetAdditionalField() != 0 {
+		t.Error("Additional server parameter not correctly instantiated")
+	}
+
+	server.RunGameLoop()
+
+	if server.GetAdditionalField() != 1 {
+		t.Error("Run Game Loop method not successfully overridden")
+	}
+
+}

--- a/pkg/main/BaseServer/serverInterface.go
+++ b/pkg/main/BaseServer/serverInterface.go
@@ -1,4 +1,4 @@
-package server
+package baseserver
 
 import baseagent "github.com/MattSScott/basePlatformSOMAS/pkg/main/BaseAgent"
 

--- a/pkg/main/messaging/agentMessenger.go
+++ b/pkg/main/messaging/agentMessenger.go
@@ -3,5 +3,5 @@ package messaging
 // // base interface structure used for message passing - can be composed for more complex message structures
 type IAgentMessenger[T any] interface {
 	// produces a list of messages (of any common interface) that an agent wishes to pass
-	GetAllMessages([]T) []IMessage[T]
+	GetAllMessages(listOfAgents []T) []IMessage[T]
 }

--- a/pkg/testing/testAgents/baseExtendedAgent/baseExtendedAgent.go
+++ b/pkg/testing/testAgents/baseExtendedAgent/baseExtendedAgent.go
@@ -23,7 +23,17 @@ func (ag *BaseExtendedAgent) GetPhrase() string {
 	return ag.phrase
 }
 
+func (ag *BaseExtendedAgent) HandleGreetingMessage(GreetingMessage) {}
+
 func GetAgent(phrase string) *BaseExtendedAgent {
+	return &BaseExtendedAgent{
+		BaseAgent: baseAgent.NewAgent[IExtendedAgent](),
+		phrase:    phrase,
+	}
+
+}
+
+func GetDefaultAgent(phrase string) IExtendedAgent {
 	return &BaseExtendedAgent{
 		BaseAgent: baseAgent.NewAgent[IExtendedAgent](),
 		phrase:    phrase,

--- a/pkg/testing/testServer/server_test.go
+++ b/pkg/testing/testServer/server_test.go
@@ -1,7 +1,7 @@
 package testserver_test
 
 import (
-	"github.com/MattSScott/basePlatformSOMAS/pkg/main/server"
+	baseserver "github.com/MattSScott/basePlatformSOMAS/pkg/main/BaseServer"
 	"github.com/MattSScott/basePlatformSOMAS/pkg/testing/testAgents/baseExtendedAgent"
 	helloagent "github.com/MattSScott/basePlatformSOMAS/pkg/testing/testAgents/helloAgent"
 	worldagent "github.com/MattSScott/basePlatformSOMAS/pkg/testing/testAgents/worldAgent"
@@ -13,10 +13,10 @@ import (
 
 func TestInheritedServer(t *testing.T) {
 
-	m := make([]server.AgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent], 5)
+	m := make([]baseserver.AgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent], 2)
 
-	m[0] = server.MakeAgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent](helloagent.GetHelloAgent, 3)
-	m[1] = server.MakeAgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent](worldagent.GetWorldAgent, 2)
+	m[0] = baseserver.MakeAgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent](helloagent.GetHelloAgent, 3)
+	m[1] = baseserver.MakeAgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent](worldagent.GetWorldAgent, 2)
 
 	floors := 3
 	ts := testserver.New(m, floors)
@@ -35,10 +35,10 @@ func TestInheritedServer(t *testing.T) {
 
 func TestServerInterfaceComposition(t *testing.T) {
 
-	m := make([]server.AgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent], 2)
+	m := make([]baseserver.AgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent], 2)
 
-	m[0] = server.MakeAgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent](helloagent.GetHelloAgent, 1)
-	m[1] = server.MakeAgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent](worldagent.GetWorldAgent, 1)
+	m[0] = baseserver.MakeAgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent](helloagent.GetHelloAgent, 1)
+	m[1] = baseserver.MakeAgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent](worldagent.GetWorldAgent, 1)
 
 	// server can also be declared as type interface
 	var server testserver.IExtendedServer = testserver.New(m, 1)
@@ -57,10 +57,10 @@ func TestServerInterfaceComposition(t *testing.T) {
 }
 
 func TestServerMessagePassing(t *testing.T) {
-	m := make([]server.AgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent], 5)
+	m := make([]baseserver.AgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent], 2)
 
-	m[0] = server.MakeAgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent](helloagent.GetHelloAgent, 1)
-	m[1] = server.MakeAgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent](worldagent.GetWorldAgent, 1)
+	m[0] = baseserver.MakeAgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent](helloagent.GetHelloAgent, 1)
+	m[1] = baseserver.MakeAgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent](worldagent.GetWorldAgent, 1)
 
 	floors := 3
 	ts := testserver.New(m, floors)

--- a/pkg/testing/testServer/testServer.go
+++ b/pkg/testing/testServer/testServer.go
@@ -1,26 +1,26 @@
 package testserver
 
 import (
-	baseServer "github.com/MattSScott/basePlatformSOMAS/pkg/main/server"
+	baseserver "github.com/MattSScott/basePlatformSOMAS/pkg/main/BaseServer"
 	"github.com/MattSScott/basePlatformSOMAS/pkg/testing/testAgents/baseExtendedAgent"
 )
 
 // the base server functionality can be extended with 'environment specific' functions
 type IExtendedServer interface {
-	baseServer.IServer[baseExtendedAgent.IExtendedAgent]
+	baseserver.IServer[baseExtendedAgent.IExtendedAgent]
 	RunAdditionalPhase()
 }
 
 // composing the 'base server' allows access to the pre-made interface implementations
 // new fields can be added to the extended server data structure
 type TestServer struct {
-	*baseServer.BaseServer[baseExtendedAgent.IExtendedAgent]
+	*baseserver.BaseServer[baseExtendedAgent.IExtendedAgent]
 	name string
 }
 
-func New(mapper []baseServer.AgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent], iterations int) *TestServer {
+func New(mapper []baseserver.AgentGeneratorCountPair[baseExtendedAgent.IExtendedAgent], iterations int) *TestServer {
 	return &TestServer{
-		BaseServer: baseServer.CreateServer[baseExtendedAgent.IExtendedAgent](mapper, iterations),
+		BaseServer: baseserver.CreateServer[baseExtendedAgent.IExtendedAgent](mapper, iterations),
 		name:       "TestServer",
 	}
 }


### PR DESCRIPTION
- networking removed from core functionality
- server package tests added
- agent package tests added
- server package renamed as `baseserver`, in line with agent style