### PR TITLE
`endListeningSession` CleanUp

### DIFF
--- a/agentGenerators.go
+++ b/agentGenerators.go
@@ -1,0 +1,15 @@
+package basePlatformSOMAS
+
+type AgentGenerator[T IAgent[T]] func(IExposedServerFunctions[T]) T
+
+type AgentGeneratorCountPair[T IAgent[T]] struct {
+	generator AgentGenerator[T]
+	count     int
+}
+
+func MakeAgentGeneratorCountPair[T IAgent[T]](generatorFunction AgentGenerator[T], count int) AgentGeneratorCountPair[T] {
+	return AgentGeneratorCountPair[T]{
+		generator: generatorFunction,
+		count:     count,
+	}
+}

--- a/agentInterface.go
+++ b/agentInterface.go
@@ -15,4 +15,6 @@ type IAgent[T any] interface {
 	NotifyAgentFinishedMessaging()
 	// allows for synchronous messaging to be run
 	RunSynchronousMessaging()
+	// allows for creation of a base message
+	CreateBaseMessage() BaseMessage
 }

--- a/baseAgent.go
+++ b/baseAgent.go
@@ -29,8 +29,7 @@ func (a *BaseAgent[T]) CreateBaseMessage() BaseMessage {
 func (a *BaseAgent[T]) UpdateAgentInternalState() {}
 
 func (a *BaseAgent[T]) NotifyAgentFinishedMessaging() {
-	a.agentStoppedTalking(a.id)
+	go a.agentStoppedTalking(a.id)
 }
 
 func (a *BaseAgent[T]) RunSynchronousMessaging() {}
-

--- a/baseServer.go
+++ b/baseServer.go
@@ -25,7 +25,7 @@ type BaseServer[T IAgent[T]] struct {
 	// number of turns for server
 	turns int
 	// mutex for agentStoppedTalkingMap access
-	agentMapRWMutex sync.RWMutex
+	//agentMapRWMutex sync.RWMutex
 	// stops multiple sends to messagingFinished during a round
 	doneChannelOnce sync.Once
 	// flag to disable async message propagation after timeout
@@ -182,7 +182,7 @@ func CreateServer[T IAgent[T]](generatorArray []AgentGeneratorCountPair[T], iter
 		iterations:              iterations,
 		turns:                   turns,
 		agentFinishedMessaging:  make(chan uuid.UUID),
-		agentMapRWMutex:         sync.RWMutex{},
+		//agentMapRWMutex:         sync.RWMutex{},
 		doneChannelOnce:         sync.Once{},
 		shouldRunAsyncMessaging: true,
 	}

--- a/baseServer.go
+++ b/baseServer.go
@@ -44,6 +44,17 @@ func (server *BaseServer[T]) HandleStartOfTurn(iter, round int) {
 	fmt.Printf("Iteration %d, Round %d starting...\n", iter, round)
 }
 
+func (serv *BaseServer[T]) resetServerAsyncHelpers() {
+
+	serv.endNotifyAgentDone.cancelNotifyAgentDone()
+	serv.shouldAllowStopTalking = false
+	newCtx, newCancel := context.WithCancel(context.Background())
+	serv.endNotifyAgentDone.endNotifyAgentDoneContext = newCtx
+	serv.endNotifyAgentDone.cancelNotifyAgentDone = newCancel
+	close(serv.agentFinishedMessaging)
+
+}
+
 func (serv *BaseServer[T]) endAgentListeningSession() bool {
 	status := true
 	ctx, cancel := context.WithTimeout(context.Background(), serv.turnTimeout)
@@ -61,12 +72,7 @@ awaitSessionEnd:
 			break awaitSessionEnd
 		}
 	}
-	serv.endNotifyAgentDone.cancelNotifyAgentDone()
-	serv.shouldAllowStopTalking = false
-	newCtx, newCancel := context.WithCancel(context.Background())
-	serv.endNotifyAgentDone.endNotifyAgentDoneContext = newCtx
-	serv.endNotifyAgentDone.cancelNotifyAgentDone = newCancel
-	close(serv.agentFinishedMessaging)
+	serv.resetServerAsyncHelpers()
 	return status
 }
 

--- a/baseServer.go
+++ b/baseServer.go
@@ -25,7 +25,7 @@ type BaseServer[T IAgent[T]] struct {
 	// number of turns for server
 	turns int
 	// mutex for agentStoppedTalkingMap access
-	endMessagingTimeout <-chan struct{}
+	endMessagingTimeout context.Context
 	// stops multiple sends to messagingFinished during a round
 	doneChannelOnce sync.Once
 	// flag to disable async message propagation after timeout
@@ -41,7 +41,7 @@ func (server *BaseServer[T]) HandleStartOfTurn(iter, round int) {
 
 func (serv *BaseServer[T]) endAgentListeningSession() bool {
 	ctx, cancel := context.WithTimeout(context.Background(), serv.turnTimeout)
-	serv.endMessagingTimeout = ctx.Done()
+	serv.endMessagingTimeout = ctx
 	defer cancel()
 
 	agentStoppedTalkingMap := make(map[uuid.UUID]struct{})
@@ -110,7 +110,7 @@ func (serv *BaseServer[T]) agentStoppedTalking(id uuid.UUID) {
 	}
 	select {
 	case serv.agentFinishedMessaging <- id:
-	case <-serv.endMessagingTimeout:
+	case <-serv.endMessagingTimeout.Done():
 	}
 }
 
@@ -186,7 +186,7 @@ func CreateServer[T IAgent[T]](generatorArray []AgentGeneratorCountPair[T], iter
 		iterations:              iterations,
 		turns:                   turns,
 		agentFinishedMessaging:  make(chan uuid.UUID),
-		endMessagingTimeout:     make(<-chan struct{}),
+		endMessagingTimeout:     context.Background(),
 		doneChannelOnce:         sync.Once{},
 		shouldRunAsyncMessaging: true,
 	}

--- a/baseServer.go
+++ b/baseServer.go
@@ -60,7 +60,7 @@ awaitSessionEnd:
 			break awaitSessionEnd
 		}
 	}
-
+	serv.endNotifyAgentDone.cancelNotifyAgentDone()
 	serv.shouldRunAsyncMessaging = false
 	newCtx, newCancel := context.WithCancel(context.Background())
 	serv.endNotifyAgentDone.endNotifyAgentDoneContext = newCtx

--- a/baseServer.go
+++ b/baseServer.go
@@ -90,10 +90,8 @@ func (serv *BaseServer[T]) Initialise() {}
 
 func (serv *BaseServer[T]) Start() {
 	serv.checkHandler()
-	turns := serv.turns
-	iterations := serv.iterations
-	for i := 0; i < iterations; i++ {
-		for j := 0; j < turns; j++ {
+	for i := 0; i < serv.iterations; i++ {
+		for j := 0; j < serv.turns; j++ {
 			serv.HandleStartOfTurn(i+1, j+1)
 			serv.roundRunner.RunTurn()
 			serv.HandleEndOfTurn(i+1, j+1)

--- a/baseServer_test.go
+++ b/baseServer_test.go
@@ -501,3 +501,14 @@ func TestGameRunner(t *testing.T) {
 		t.Errorf("Server unable to run turn: have turn value %d, expected %d", runHandler.turns, 1)
 	}
 }
+
+func TestNotifyStoppedTalkingTimeout(t *testing.T) {
+	m := make([]basePlatformSOMAS.AgentGeneratorCountPair[ITestBaseAgent], 1)
+	m[0] = basePlatformSOMAS.MakeAgentGeneratorCountPair(NewTestAgent, 1)
+	timeLimit := 100 * time.Millisecond
+	server := NewTestServer(m, 1, 1, timeLimit)
+	server.EndAgentListeningSession()
+	for _,ag := range server.GetAgentMap() {
+		ag.NotifyAgentFinishedMessaging()
+	}
+}

--- a/baseServer_test.go
+++ b/baseServer_test.go
@@ -1,10 +1,7 @@
 package basePlatformSOMAS_test
 
 import (
-	"bytes"
 	"fmt"
-	"io"
-	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -34,9 +31,9 @@ type ITestServer interface {
 }
 
 type TestAgent struct {
+	*basePlatformSOMAS.BaseAgent[ITestBaseAgent]
 	counter int64
 	goal    int64
-	*basePlatformSOMAS.BaseAgent[ITestBaseAgent]
 }
 
 type TestServer struct {
@@ -427,27 +424,33 @@ func TestAccessAgentByID(t *testing.T) {
 }
 
 func TestMessagePrint(t *testing.T) {
-	m := make([]basePlatformSOMAS.AgentGeneratorCountPair[ITestBaseAgent], 1)
-	m[0] = basePlatformSOMAS.MakeAgentGeneratorCountPair(NewTestAgent, 1)
-	server := basePlatformSOMAS.CreateServer(m, 1, 1, time.Second)
-	ag := NewTestAgent(server)
-	newMsg := ag.NewTestMessage()
-	newMsg.Print()
-	originalStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-	newMsg.Print()
-	w.Close()
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
-	output := buf.String()
-	os.Stdout = originalStdout
-	expected := "message received from " + ag.GetID().String() + "\n"
-	if string(output) != string(expected) {
-		t.Error("Expected", expected, "but got", output)
-	}
-
+	ag := NewTestAgent(nil)
+	msg := ag.CreateBaseMessage()
+	msg.Print()
 }
+
+// func TestMessagePrint(t *testing.T) {
+// 	m := make([]basePlatformSOMAS.AgentGeneratorCountPair[ITestBaseAgent], 1)
+// 	m[0] = basePlatformSOMAS.MakeAgentGeneratorCountPair(NewTestAgent, 1)
+// 	server := basePlatformSOMAS.CreateServer(m, 1, 1, time.Second)
+// 	ag := NewTestAgent(server)
+// 	newMsg := ag.NewTestMessage()
+// 	newMsg.Print()
+// 	originalStdout := os.Stdout
+// 	r, w, _ := os.Pipe()
+// 	os.Stdout = w
+// 	newMsg.Print()
+// 	w.Close()
+// 	var buf bytes.Buffer
+// 	io.Copy(&buf, r)
+// 	output := buf.String()
+// 	os.Stdout = originalStdout
+// 	expected := "message received from " + ag.GetID().String() + "\n"
+// 	if string(output) != string(expected) {
+// 		t.Error("Expected", expected, "but got", output)
+// 	}
+
+// }
 
 func (tba *TestServer) infMessageSend(newMsg InfiniteLoopMessage, receiver []uuid.UUID, done chan struct{}) {
 	go tba.SendMessage(newMsg, receiver)

--- a/baseServer_test.go
+++ b/baseServer_test.go
@@ -183,11 +183,7 @@ func TestAgentsCorrectlyInstantiated(t *testing.T) {
 	m := make([]basePlatformSOMAS.AgentGeneratorCountPair[ITestBaseAgent], 1)
 	m[0] = basePlatformSOMAS.MakeAgentGeneratorCountPair(NewTestAgent, numAgents)
 
-	server := basePlatformSOMAS.CreateServer(m, 1, 1, time.Second)
-
-	ag := NewTestAgent(server)
-	server.EndAgentListeningSession()
-	go ag.NotifyAgentFinishedMessaging()
+	server := basePlatformSOMAS.CreateServer(m, 1, 1, 1*time.Second)
 
 	lenAgentMap := len(server.GetAgentMap())
 	if lenAgentMap != numAgents {

--- a/baseServer_test.go
+++ b/baseServer_test.go
@@ -15,10 +15,10 @@ type ITestBaseAgent interface {
 	NewTestMessage() TestMessage
 	HandleTestMessage()
 	ReceivedMessage() bool
-	GetCounter() int64
-	SetCounter(int64)
-	GetGoal() int64
-	SetGoal(int64)
+	GetCounter() int32
+	SetCounter(int32)
+	GetGoal() int32
+	SetGoal(int32)
 }
 
 type IBadAgent interface {
@@ -31,9 +31,9 @@ type ITestServer interface {
 }
 
 type TestAgent struct {
+	counter int32
+	goal    int32
 	*basePlatformSOMAS.BaseAgent[ITestBaseAgent]
-	counter int64
-	goal    int64
 }
 
 type TestServer struct {
@@ -85,14 +85,14 @@ func InfLoop() {
 		time.Sleep(1000 * time.Millisecond)
 	}
 }
-func (tba *TestAgent) SetCounter(count int64) {
+func (tba *TestAgent) SetCounter(count int32) {
 	tba.counter = count
 }
 
-func (tba *TestAgent) SetGoal(goal int64) {
+func (tba *TestAgent) SetGoal(goal int32) {
 	tba.goal = goal
 }
-func (tba *TestAgent) GetGoal() int64 {
+func (tba *TestAgent) GetGoal() int32 {
 	return tba.goal
 }
 func NewTestMessage() TestMessage {
@@ -125,7 +125,7 @@ func (ta *TestAgent) NewTestMessage() TestMessage {
 	}
 }
 
-func (ta *TestAgent) GetCounter() int64 {
+func (ta *TestAgent) GetCounter() int32 {
 	return ta.counter
 }
 func (ag *TestAgent) RunSynchronousMessaging() {
@@ -149,8 +149,8 @@ func (ts *TestServer) RunRound() {
 }
 
 func (ag *TestAgent) HandleTestMessage() {
-	newCounterValue := atomic.AddInt64(&ag.counter, 1)
-	if newCounterValue == atomic.LoadInt64(&ag.goal) {
+	newCounterValue := atomic.AddInt32(&ag.counter, 1)
+	if newCounterValue == atomic.LoadInt32(&ag.goal) {
 		ag.NotifyAgentFinishedMessaging()
 	}
 }
@@ -297,7 +297,7 @@ func TestWaitForMessagingToEnd(t *testing.T) {
 	for id, ag := range agentMap {
 		arrayOfIDs[i] = id
 		i++
-		ag.SetGoal(int64(numberOfMessages * numAgents))
+		ag.SetGoal(int32(numberOfMessages * numAgents))
 	}
 
 	for j := 0; j < numberOfMessages; j++ {
@@ -393,7 +393,7 @@ func TestSynchronousMessagingSession(t *testing.T) {
 	server.RunSynchronousMessagingSession()
 	for _, ag := range server.GetAgentMap() {
 
-		if ag.GetCounter() != int64(numberAgents-1) {
+		if ag.GetCounter() != int32(numberAgents-1) {
 			t.Error("All messages did not pass, got:", ag.GetCounter(), "expected:", numberAgents-1)
 		}
 	}
@@ -401,7 +401,7 @@ func TestSynchronousMessagingSession(t *testing.T) {
 
 func TestAccessAgentByID(t *testing.T) {
 	numberAgents := 10
-	var randNum int64 = 2357
+	var randNum int32 = 2357
 	m := make([]basePlatformSOMAS.AgentGeneratorCountPair[ITestBaseAgent], 1)
 	m[0] = basePlatformSOMAS.MakeAgentGeneratorCountPair(NewTestAgent, numberAgents)
 	server := basePlatformSOMAS.CreateServer(m, 1, 1, time.Second)

--- a/baseServer_test.go
+++ b/baseServer_test.go
@@ -491,11 +491,12 @@ func testNotify(goal int32, count *int32, ag ITestBaseAgent, finished chan struc
 	}
 }
 
-func sendNotifyMessages(agMap map[uuid.UUID]ITestBaseAgent, goal int32, count *int32, finished chan struct{}) {
-	for i := 0;i < 2 ; i++ {
+func sendNotifyMessages(agMap map[uuid.UUID]ITestBaseAgent, goal int32, count *int32, finished chan struct{}, iter int) {
 	for _, ag := range agMap {
-		go testNotify(goal, count, ag, finished)
-	}}
+		for i := 0; i < iter; i++ {
+			go testNotify(goal*int32(iter), count, ag, finished)
+		}
+	}
 }
 
 func waitForNotifyFinishedMessagingExit(finished chan struct{}) bool {
@@ -517,13 +518,13 @@ func TestNotifyStoppedTalkingTimeout(t *testing.T) {
 	finished := make(chan struct{})
 	server := GenerateTestServer(numAgents, 1, 1, timeLimit)
 	numAgentsInt32 := int32(numAgents)
-	sendNotifyMessages(server.GetAgentMap(), 2*numAgentsInt32, &counter, finished)
+	sendNotifyMessages(server.GetAgentMap(), numAgentsInt32, &counter, finished, 5)
 	if !waitForNotifyFinishedMessagingExit(finished) {
 		t.Error("timeout. Number of NotifyAgentFinishedMessaging functions exited:", counter, "expected:", numAgents)
 	}
 	server.EndAgentListeningSession()
 	counter = 0
-	sendNotifyMessages(server.GetAgentMap(), 2*numAgentsInt32, &counter, finished)
+	sendNotifyMessages(server.GetAgentMap(), numAgentsInt32, &counter, finished, 2)
 
 	if !waitForNotifyFinishedMessagingExit(finished) {
 		t.Error("timeout. Number of NotifyAgentFinishedMessaging functions exited:", counter, "expected:", numAgents)

--- a/baseServer_test.go
+++ b/baseServer_test.go
@@ -492,9 +492,10 @@ func testNotify(goal int32, count *int32, ag ITestBaseAgent, finished chan struc
 }
 
 func sendNotifyMessages(agMap map[uuid.UUID]ITestBaseAgent, goal int32, count *int32, finished chan struct{}) {
+	for i := 0;i < 2 ; i++ {
 	for _, ag := range agMap {
 		go testNotify(goal, count, ag, finished)
-	}
+	}}
 }
 
 func waitForNotifyFinishedMessagingExit(finished chan struct{}) bool {
@@ -516,13 +517,13 @@ func TestNotifyStoppedTalkingTimeout(t *testing.T) {
 	finished := make(chan struct{})
 	server := GenerateTestServer(numAgents, 1, 1, timeLimit)
 	numAgentsInt32 := int32(numAgents)
-	sendNotifyMessages(server.GetAgentMap(), numAgentsInt32, &counter, finished)
+	sendNotifyMessages(server.GetAgentMap(), 2*numAgentsInt32, &counter, finished)
 	if !waitForNotifyFinishedMessagingExit(finished) {
 		t.Error("timeout. Number of NotifyAgentFinishedMessaging functions exited:", counter, "expected:", numAgents)
 	}
 	server.EndAgentListeningSession()
 	counter = 0
-	sendNotifyMessages(server.GetAgentMap(), numAgentsInt32, &counter, finished)
+	sendNotifyMessages(server.GetAgentMap(), 2*numAgentsInt32, &counter, finished)
 
 	if !waitForNotifyFinishedMessagingExit(finished) {
 		t.Error("timeout. Number of NotifyAgentFinishedMessaging functions exited:", counter, "expected:", numAgents)

--- a/getters_test.go
+++ b/getters_test.go
@@ -1,5 +1,10 @@
 package basePlatformSOMAS
 
+import (
+	"sync"
+	"sync/atomic"
+)
+
 type PrivateServerFields[T IAgent[T]] interface {
 	EndAgentListeningSession()
 }
@@ -10,4 +15,10 @@ func (serv *BaseServer[T]) EndAgentListeningSession() bool {
 
 func (serv *BaseServer[T]) EndAsyncMessaging() {
 	serv.shouldAllowStopTalking = false
+}
+
+func (ag *BaseAgent[T]) NotifyAgentFinishedMessagingUnthreaded(wg *sync.WaitGroup, counter *uint32) {
+	defer wg.Done()
+	ag.agentStoppedTalking(ag.id)
+	atomic.AddUint32(counter, 1)
 }

--- a/getters_test.go
+++ b/getters_test.go
@@ -9,5 +9,5 @@ func (serv *BaseServer[T]) EndAgentListeningSession() bool {
 }
 
 func (serv *BaseServer[T]) EndAsyncMessaging() {
-	serv.shouldRunAsyncMessaging = false
+	serv.shouldAllowStopTalking = false
 }

--- a/getters_test.go
+++ b/getters_test.go
@@ -2,8 +2,6 @@ package basePlatformSOMAS
 
 type PrivateServerFields[T IAgent[T]] interface {
 	EndAgentListeningSession()
-	IncrementWaitGroup()
-	WaitWaitGroup()
 }
 
 func (serv *BaseServer[T]) EndAgentListeningSession() bool {

--- a/message.go
+++ b/message.go
@@ -6,12 +6,6 @@ import (
 	"github.com/google/uuid"
 )
 
-// // base interface structure used for message passing - can be composed for more complex message structures
-// type IAgentMessenger interface {
-// 	// produces a list of messages (of any common interface) that an agent wishes to pass
-// 	GetAllMessages(listOfAgents []T) []IMessage[T]
-// }
-
 // base interface structure used for message - can be composed for more complex message structures
 type IMessage[T any] interface {
 	// returns the sender of a message
@@ -27,9 +21,6 @@ type BaseMessage struct {
 	sender uuid.UUID
 }
 
-// create read-only message instance
-
-
 func (bm BaseMessage) Print() {
 	fmt.Printf("message received from %s\n", bm.sender)
 }
@@ -37,4 +28,3 @@ func (bm BaseMessage) Print() {
 func (bm BaseMessage) GetSender() uuid.UUID {
 	return bm.sender
 }
-

--- a/serverInterface.go
+++ b/serverInterface.go
@@ -47,4 +47,3 @@ type RoundRunner interface {
 	RunRound()
 	RunTurn()
 }
-


### PR DESCRIPTION
- By handling the reading / writing of the agent map inside of the server's main thread, we avoid needing mutexes
- We also avoid the worry of writing to a closed channel, since we handle the channel closure in the main thread
- We can hence safely remove both the mutexes and 'done' channel map