### PR TITLE
distribute semaphore across agents

### DIFF
--- a/internal/testUtils/testUtilsAgent.go
+++ b/internal/testUtils/testUtilsAgent.go
@@ -108,6 +108,8 @@ func (ta *TestServerFunctionsAgent) HandleTimeoutTestMessage(msg TestTimeoutMess
 }
 
 func (ta *TestServerFunctionsAgent) HandleInfiniteLoopMessage(msg TestMessagingBandwidthLimiter) {
-	// two or more agents broadcasting will cause infinite recursive calls
-	ta.BroadcastMessage(&msg)
+	// two or more agents sending to each other repeatedly will cause infinite recursive calls
+	originalSender := msg.GetSender()
+	msg.SetSender(ta.GetID())
+	ta.SendMessage(&msg, originalSender)
 }

--- a/internal/testUtils/testUtilsAgent.go
+++ b/internal/testUtils/testUtilsAgent.go
@@ -104,7 +104,7 @@ func (ta *TestServerFunctionsAgent) HandleTimeoutTestMessage(msg TestTimeoutMess
 	start := time.Now()
 	time.Sleep(msg.Workload) // simulate long work
 	fmt.Println("work has been completed, took ", time.Since(start), "notifying finished messaging")
-	//ta.NotifyAgentFinishedMessaging()
+	ta.NotifyAgentFinishedMessaging()
 }
 
 func (ta *TestServerFunctionsAgent) HandleInfiniteLoopMessage(msg TestMessagingBandwidthLimiter) {

--- a/internal/testUtils/testUtilsAgent.go
+++ b/internal/testUtils/testUtilsAgent.go
@@ -1,6 +1,7 @@
 package testUtils
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -100,8 +101,10 @@ func (ta *TestServerFunctionsAgent) GetGoal() int32 {
 }
 
 func (ta *TestServerFunctionsAgent) HandleTimeoutTestMessage(msg TestTimeoutMessage) {
+	start := time.Now()
 	time.Sleep(msg.Workload) // simulate long work
-	ta.NotifyAgentFinishedMessaging()
+	fmt.Println("work has been completed, took ", time.Since(start), "notifying finished messaging")
+	//ta.NotifyAgentFinishedMessaging()
 }
 
 func (ta *TestServerFunctionsAgent) HandleInfiniteLoopMessage(msg TestMessagingBandwidthLimiter) {

--- a/pkg/agent/agentInterface.go
+++ b/pkg/agent/agentInterface.go
@@ -18,13 +18,16 @@ type IAgent[T any] interface {
 	RunSynchronousMessaging()
 	// allows for creation of a base message
 	CreateBaseMessage() message.BaseMessage
+	// allows for sending a message across the entire system
 	BroadcastMessage(message.IMessage[T])
+	// allows for sending a message to a single recipient
+	SendMessage(message.IMessage[T], uuid.UUID)
+	// allows for sending a message to a single recipient synchronously
+	SendSynchronousMessage(message.IMessage[T], uuid.UUID)
 }
 
 type IMessagingProtocol[T any] interface {
-	SendSynchronousMessage(message.IMessage[T], uuid.UUID)
-	SendMessage(message.IMessage[T], uuid.UUID)
-	//BroadcastMessage(message.IMessage[T])
+	DeliverMessage(message.IMessage[T], uuid.UUID)
 	AgentStoppedTalking(uuid.UUID)
 }
 
@@ -34,5 +37,6 @@ type IExposedServerFunctions[T any] interface {
 	ViewAgentIdSet() map[uuid.UUID]struct{}
 	// return exposed functions for agent
 	AccessAgentByID(uuid.UUID) T
+	// return max number of threads spawnable by an agent
 	GetAgentMessagingBandwidth() int
 }

--- a/pkg/agent/agentInterface.go
+++ b/pkg/agent/agentInterface.go
@@ -18,12 +18,13 @@ type IAgent[T any] interface {
 	RunSynchronousMessaging()
 	// allows for creation of a base message
 	CreateBaseMessage() message.BaseMessage
+	BroadcastMessage(message.IMessage[T])
 }
 
 type IMessagingProtocol[T any] interface {
 	SendSynchronousMessage(message.IMessage[T], uuid.UUID)
 	SendMessage(message.IMessage[T], uuid.UUID)
-	BroadcastMessage(message.IMessage[T])
+	//BroadcastMessage(message.IMessage[T])
 	AgentStoppedTalking(uuid.UUID)
 }
 
@@ -33,4 +34,5 @@ type IExposedServerFunctions[T any] interface {
 	ViewAgentIdSet() map[uuid.UUID]struct{}
 	// return exposed functions for agent
 	AccessAgentByID(uuid.UUID) T
+	GetAgentMessagingBandwidth() int
 }

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -95,9 +95,9 @@ func TestBroadCastMessage(t *testing.T) {
 	senderID := agent1.GetID()
 	server.EndAgentListeningSession()
 	for _, ag := range server.GetAgentMap() {
-		if !ag.ReceivedMessage()  && ag.GetID() != senderID {
+		if !ag.ReceivedMessage() && ag.GetID() != senderID {
 			t.Error(ag, "Didn't Receive Message")
-		}else if ag.ReceivedMessage()  && ag.GetID() == senderID {
+		} else if ag.ReceivedMessage() && ag.GetID() == senderID {
 			t.Error(ag, "is sender and received its own message")
 		}
 	}
@@ -139,7 +139,7 @@ func TestSendMessageNoIDPanic(t *testing.T) {
 	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Millisecond, 100000)
 	agMap := server.GetAgentMap()
 
-	for _,ag := range agMap {
+	for _, ag := range agMap {
 		msg := &testUtils.TestMessage{}
 		for recip := range agMap {
 			ag.SendMessage(msg, recip)

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -23,6 +23,16 @@ func TestAgentIdOperations(t *testing.T) {
 	}
 }
 
+func TestNilInterfaceInjection(t *testing.T) {
+	defer func() {
+		if panicValue := recover(); panicValue == nil {
+			t.Errorf("did not panic when nil interface injected")
+		}
+	}()
+	ag := agent.CreateBaseAgent[testUtils.ITestBaseAgent](nil)
+	ag.GetID()
+}
+
 func TestUpdateAgentInternalState(t *testing.T) {
 	var testServ agent.IExposedServerFunctions[testUtils.ITestBaseAgent] = &testUtils.TestServer{
 		BaseServer:            server.CreateServer[testUtils.ITestBaseAgent](1, 1, time.Second, 100),

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -156,3 +156,35 @@ func TestSendMessageNoIDPanic(t *testing.T) {
 		}
 	}
 }
+
+func TestSendSynchronousMessageNoIDPanic(t *testing.T) {
+	defer func() {
+		if panicValue := recover(); panicValue == nil {
+			t.Errorf("did not panic when message sender not set")
+		}
+	}()
+	numAgents := 2
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Millisecond, 100)
+	agMap := server.GetAgentMap()
+	for _, ag := range agMap {
+		msg := &testUtils.TestMessage{}
+		for recip := range agMap {
+			ag.SendSynchronousMessage(msg, recip)
+		}
+	}
+}
+
+func TestSendSynchronousMessage(t *testing.T) {
+	numAgents := 10
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100)
+	testMessage := testUtils.NewTestAgent(server).CreateTestMessage()
+	for id, ag := range server.GetAgentMap() {
+		ag.SetGoal(1)
+		ag.SendSynchronousMessage(testMessage, id)
+	}
+	for _, ag := range server.GetAgentMap() {
+		if !ag.ReceivedMessage() {
+			t.Error("Didn't Receive Message")
+		}
+	}
+}

--- a/pkg/agent/baseAgent.go
+++ b/pkg/agent/baseAgent.go
@@ -44,11 +44,18 @@ func (a *BaseAgent[T]) SendMessage(msg message.IMessage[T], recipient uuid.UUID)
 	select {
 	case a.messageLimiterSemaphore <- struct{}{}:
 		go func() {
-			a.IExposedServerFunctions.SendMessage(msg, recipient)
+			a.DeliverMessage(msg, recipient)
 			<-a.messageLimiterSemaphore
 		}()
 	default:
 	}
+}
+
+func (a *BaseAgent[T]) SendSynchronousMessage(msg message.IMessage[T], recipient uuid.UUID) {
+	if msg.GetSender() == uuid.Nil {
+		panic("No sender found - did you compose the BaseMessage?")
+	}
+	a.DeliverMessage(msg, recipient)
 }
 
 func (agent *BaseAgent[T]) BroadcastMessage(msg message.IMessage[T]) {

--- a/pkg/agent/baseAgent.go
+++ b/pkg/agent/baseAgent.go
@@ -16,6 +16,9 @@ func (a *BaseAgent[T]) GetID() uuid.UUID {
 }
 
 func CreateBaseAgent[T IAgent[T]](serv IExposedServerFunctions[T]) *BaseAgent[T] {
+	if serv == nil {
+		panic("Nil interface passed to CreateBaseAgent. Please pass an instance of IExposedServerFunctions")
+	}
 	return &BaseAgent[T]{
 		IExposedServerFunctions: serv,
 		id:                      uuid.New(),

--- a/pkg/message/message_test.go
+++ b/pkg/message/message_test.go
@@ -58,7 +58,6 @@ func TestPrint(t *testing.T) {
 	newMsg := a1.GetMessage1()
 	newMsg.Print()
 }
-
 func TestGetSender(t *testing.T) {
 	server := server.CreateServer[testUtils.IExtendedAgent](1, 1, time.Second, 100000)
 	a1 := testUtils.NewExtendedAgent(server)

--- a/pkg/message/message_test.go
+++ b/pkg/message/message_test.go
@@ -2,14 +2,17 @@ package message_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/MattSScott/basePlatformSOMAS/internal/testUtils"
 	"github.com/MattSScott/basePlatformSOMAS/pkg/message"
+	"github.com/MattSScott/basePlatformSOMAS/pkg/server"
 )
 
 func TestMessageCanBeExtended(t *testing.T) {
-	agent1 := testUtils.NewExtendedAgent(nil)
-	agent2 := testUtils.NewExtendedAgent(nil)
+	server := server.CreateServer[testUtils.IExtendedAgent](1, 1, time.Second, 100000)
+	agent1 := testUtils.NewExtendedAgent(server)
+	agent2 := testUtils.NewExtendedAgent(server)
 	msgFromA1 := agent1.GetMessage1()
 	msgFromA1.InvokeMessageHandler(agent2)
 	msgFromA2 := agent2.GetMessage2()
@@ -23,9 +26,10 @@ func TestMessageCanBeExtended(t *testing.T) {
 }
 
 func TestSingleMessageGetsHandled(t *testing.T) {
-	a1 := testUtils.NewExtendedAgent(nil)
-	a2 := testUtils.NewExtendedAgent(nil)
-	a3 := testUtils.NewExtendedAgent(nil)
+	server := server.CreateServer[testUtils.IExtendedAgent](1, 1, time.Second, 100000)
+	a1 := testUtils.NewExtendedAgent(server)
+	a2 := testUtils.NewExtendedAgent(server)
+	a3 := testUtils.NewExtendedAgent(server)
 	nullMsg := a1.GetNullMessage()
 	for _, recip := range []testUtils.IExtendedAgent{a2, a3} {
 		nullMsg.InvokeMessageHandler(recip)
@@ -36,8 +40,9 @@ func TestSingleMessageGetsHandled(t *testing.T) {
 }
 
 func TestMultipleMessagesGetHandled(t *testing.T) {
-	a1 := testUtils.NewExtendedAgent(nil)
-	a2 := testUtils.NewExtendedAgent(nil)
+	server := server.CreateServer[testUtils.IExtendedAgent](1, 1, time.Second, 100000)
+	a1 := testUtils.NewExtendedAgent(server)
+	a2 := testUtils.NewExtendedAgent(server)
 	allMessages := []message.IMessage[testUtils.IExtendedAgent]{a1.GetMessage1(), a1.GetMessage1(), a1.GetMessage2()}
 	for _, msg := range allMessages {
 		msg.InvokeMessageHandler(a2)
@@ -48,13 +53,15 @@ func TestMultipleMessagesGetHandled(t *testing.T) {
 }
 
 func TestPrint(t *testing.T) {
-	a1 := testUtils.NewExtendedAgent(nil)
+	server := server.CreateServer[testUtils.IExtendedAgent](1, 1, time.Second, 100000)
+	a1 := testUtils.NewExtendedAgent(server)
 	newMsg := a1.GetMessage1()
 	newMsg.Print()
 }
 
 func TestGetSender(t *testing.T) {
-	a1 := testUtils.NewExtendedAgent(nil)
+	server := server.CreateServer[testUtils.IExtendedAgent](1, 1, time.Second, 100000)
+	a1 := testUtils.NewExtendedAgent(server)
 	msg := a1.GetMessage1()
 	agID := a1.GetID()
 	msgSenderID := msg.GetSender()

--- a/pkg/server/baseServer.go
+++ b/pkg/server/baseServer.go
@@ -58,7 +58,7 @@ func (server *BaseServer[T]) HandleEndOfTurn() {
 	server.EndAgentListeningSession()
 }
 
-func (server *BaseServer[T]) SendMessage(msg message.IMessage[T], recipient uuid.UUID) {
+func (server *BaseServer[T]) DeliverMessage(msg message.IMessage[T], recipient uuid.UUID) {
 	msg.InvokeMessageHandler(server.agentMap[recipient])
 }
 
@@ -134,16 +134,6 @@ func (serv *BaseServer[T]) GetIterations() int {
 func (serv *BaseServer[T]) RemoveAgent(agentToRemove T) {
 	delete(serv.agentMap, agentToRemove.GetID())
 	delete(serv.agentIdSet, agentToRemove.GetID())
-}
-
-func (serv *BaseServer[T]) SendSynchronousMessage(msg message.IMessage[T], recip uuid.UUID) {
-	if msg.GetSender() == uuid.Nil {
-		panic("No sender found - did you compose the BaseMessage?")
-	}
-	if msg.GetSender() == recip {
-		return
-	}
-	msg.InvokeMessageHandler(serv.agentMap[recip])
 }
 
 func (serv *BaseServer[T]) RunSynchronousMessagingSession() {

--- a/pkg/server/baseServer.go
+++ b/pkg/server/baseServer.go
@@ -26,8 +26,8 @@ type BaseServer[T agent.IAgent[T]] struct {
 	turns int
 	// closable channel to signify that messaging is complete
 	endNotifyAgentDone chan struct{}
-	// limits the number of sendmessage goroutines executing at once
-	messageSenderSemaphore chan struct{}
+	//the max number of sent messages the server will process concurrently from each agent at one time. Anymore sent will be dropped
+	agentMessagingBandwidth int
 }
 
 func (server *BaseServer[T]) HandleStartOfTurn() {
@@ -59,29 +59,7 @@ func (server *BaseServer[T]) HandleEndOfTurn() {
 }
 
 func (server *BaseServer[T]) SendMessage(msg message.IMessage[T], recipient uuid.UUID) {
-	if msg.GetSender() == uuid.Nil {
-		panic("No sender found - did you compose the BaseMessage?")
-	}
-	select {
-	case server.messageSenderSemaphore <- struct{}{}:
-		go func() {
-			msg.InvokeMessageHandler(server.agentMap[recipient])
-			<-server.messageSenderSemaphore
-		}()
-	default:
-	}
-}
-
-func (server *BaseServer[T]) BroadcastMessage(msg message.IMessage[T]) {
-	if msg.GetSender() == uuid.Nil {
-		panic("No sender found - did you compose the BaseMessage?")
-	}
-	for id := range server.ViewAgentIdSet() {
-		if id == msg.GetSender() {
-			continue
-		}
-		server.SendMessage(msg, id)
-	}
+	msg.InvokeMessageHandler(server.agentMap[recipient])
 }
 
 func (serv *BaseServer[T]) AddAgent(agent T) {
@@ -174,17 +152,21 @@ func (serv *BaseServer[T]) RunSynchronousMessagingSession() {
 	}
 }
 
+func (serv *BaseServer[T]) GetAgentMessagingBandwidth() int {
+	return serv.agentMessagingBandwidth
+}
+
 // generate a server instance based on a mapping function and number of iterations
 func CreateServer[T agent.IAgent[T]](iterations, turns int, turnMaxDuration time.Duration, messageBandwidth int) *BaseServer[T] {
 	return &BaseServer[T]{
-		agentMap:               make(map[uuid.UUID]T),
-		agentIdSet:             make(map[uuid.UUID]struct{}),
-		turnTimeout:            turnMaxDuration,
-		gameRunner:             nil,
-		iterations:             iterations,
-		turns:                  turns,
-		agentFinishedMessaging: make(chan uuid.UUID),
-		endNotifyAgentDone:     make(chan struct{}),
-		messageSenderSemaphore: make(chan struct{}, messageBandwidth),
+		agentMap:                make(map[uuid.UUID]T),
+		agentIdSet:              make(map[uuid.UUID]struct{}),
+		turnTimeout:             turnMaxDuration,
+		gameRunner:              nil,
+		iterations:              iterations,
+		turns:                   turns,
+		agentFinishedMessaging:  make(chan uuid.UUID),
+		endNotifyAgentDone:      make(chan struct{}),
+		agentMessagingBandwidth: messageBandwidth,
 	}
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -94,9 +94,9 @@ func TestRemoveAgent(t *testing.T) {
 }
 
 func TestWaitForMessagingToEnd(t *testing.T) {
-	numMessages := 100
+	numMessages := 20
 	numAgents := 10
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, 10*time.Millisecond, 200)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, 5*time.Millisecond, 200)
 	agentMap := server.GetAgentMap()
 	agentGoal := int32(numMessages * numAgents)
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -96,7 +96,7 @@ func TestRemoveAgent(t *testing.T) {
 func TestWaitForMessagingToEnd(t *testing.T) {
 	numMessages := 100
 	numAgents := 10
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Millisecond, 200)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, 10*time.Millisecond, 200)
 	agentMap := server.GetAgentMap()
 	agentGoal := int32(numMessages * numAgents)
 
@@ -322,7 +322,7 @@ func TestSendMessageNoIDPanic(t *testing.T) {
 	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Millisecond, 100)
 	agMap := server.GetAgentMap()
 
-	for _,ag := range agMap {
+	for _, ag := range agMap {
 		msg := &testUtils.TestMessage{}
 		for recip := range agMap {
 			ag.SendMessage(msg, recip)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -50,7 +50,7 @@ func TestRunTurn(t *testing.T) {
 	}
 }
 
-func TestSendMessage(t *testing.T) {
+func TestDeliverMessage(t *testing.T) {
 	numAgents := 2
 	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100)
 	agent1 := testUtils.NewTestAgent(server)
@@ -93,7 +93,7 @@ func TestRemoveAgent(t *testing.T) {
 	}
 }
 
-func TestWaitForMessagingToEnd(t *testing.T) {
+func TestEndAgentListeningSession(t *testing.T) {
 	numMessages := 20
 	numAgents := 10
 	server := testUtils.GenerateTestServer(numAgents, 1, 1, 5*time.Millisecond, 200)
@@ -156,21 +156,6 @@ func TestBroadcastMessage(t *testing.T) {
 	for _, ag := range server.GetAgentMap() {
 		if !ag.ReceivedMessage() {
 			t.Error(ag, "Didn't Receive Message")
-		}
-	}
-}
-
-func TestSendSynchronousMessage(t *testing.T) {
-	numAgents := 10
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100)
-	testMessage := testUtils.NewTestAgent(server).CreateTestMessage()
-	for id, ag := range server.GetAgentMap() {
-		ag.SetGoal(1)
-		ag.SendSynchronousMessage(testMessage, id)
-	}
-	for _, ag := range server.GetAgentMap() {
-		if !ag.ReceivedMessage() {
-			t.Error("Didn't Receive Message")
 		}
 	}
 }
@@ -325,23 +310,6 @@ func TestSendMessageNoIDPanic(t *testing.T) {
 		msg := &testUtils.TestMessage{}
 		for recip := range agMap {
 			ag.SendMessage(msg, recip)
-		}
-	}
-}
-
-func TestSendSynchronousMessageNoIDPanic(t *testing.T) {
-	defer func() {
-		if panicValue := recover(); panicValue == nil {
-			t.Errorf("did not panic when message sender not set")
-		}
-	}()
-	numAgents := 2
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Millisecond, 100)
-	agMap := server.GetAgentMap()
-	for _, ag := range agMap {
-		msg := &testUtils.TestMessage{}
-		for recip := range agMap {
-			ag.SendSynchronousMessage(msg, recip)
 		}
 	}
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestGenerateServer(t *testing.T) {
 	numAgents := 2
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100000)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100)
 	lenAgentMap := len(server.GetAgentMap())
 	if lenAgentMap != numAgents {
 		t.Error(lenAgentMap, "agents initialised, expected:", numAgents)
@@ -21,7 +21,7 @@ func TestGenerateServer(t *testing.T) {
 
 func TestAgentsCorrectlyInstantiated(t *testing.T) {
 	numAgents := 2
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100000)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100)
 	lenAgentMap := len(server.GetAgentMap())
 	if lenAgentMap != numAgents {
 		t.Error("Incorrect number of agents added to server,got", lenAgentMap, "expected", numAgents)
@@ -34,7 +34,7 @@ func TestHandlerInitialiser(t *testing.T) {
 		}
 	}()
 	numAgents := 2
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100000)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100)
 	server.Start()
 }
 
@@ -42,7 +42,7 @@ func TestRunTurn(t *testing.T) {
 	numAgents := 20
 	iterations := 1
 	turns := 1
-	server := testUtils.GenerateTestServer(numAgents, iterations, turns, time.Millisecond, 100000)
+	server := testUtils.GenerateTestServer(numAgents, iterations, turns, time.Millisecond, 100)
 	server.SetGameRunner(server)
 	server.Start()
 	if server.TurnCounter != (iterations * turns) {
@@ -50,9 +50,9 @@ func TestRunTurn(t *testing.T) {
 	}
 }
 
-func TestAgentRecievesMessage(t *testing.T) {
+func TestSendMessage(t *testing.T) {
 	numAgents := 2
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100000)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100)
 	agent1 := testUtils.NewTestAgent(server)
 	testMessage := agent1.CreateTestMessage()
 	for id, ag := range server.GetAgentMap() {
@@ -69,7 +69,7 @@ func TestAgentRecievesMessage(t *testing.T) {
 
 func TestAddAgent(t *testing.T) {
 	numAgents := 2
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100000)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100)
 	agent := testUtils.NewTestAgent(server)
 	server.AddAgent(agent)
 	agMap := server.GetAgentMap()
@@ -82,7 +82,7 @@ func TestAddAgent(t *testing.T) {
 
 func TestRemoveAgent(t *testing.T) {
 	numAgents := 2
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100000)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100)
 	agMap := server.GetAgentMap()
 	for _, ag := range agMap {
 		server.RemoveAgent(ag)
@@ -96,7 +96,7 @@ func TestRemoveAgent(t *testing.T) {
 func TestWaitForMessagingToEnd(t *testing.T) {
 	numMessages := 100
 	numAgents := 10
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Millisecond, 100000)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Millisecond, 200)
 	agentMap := server.GetAgentMap()
 	agentGoal := int32(numMessages * numAgents)
 
@@ -125,7 +125,7 @@ func TestWaitForMessagingToEnd(t *testing.T) {
 func TestNumIterationsInServer(t *testing.T) {
 	iterations := 1
 	numAgents := 2
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100000)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100)
 	getIterationsValue := server.GetIterations()
 	if getIterationsValue != iterations {
 		t.Error("Incorrect number of iterations instantiated, expected:", iterations, "got:", getIterationsValue)
@@ -135,7 +135,7 @@ func TestNumIterationsInServer(t *testing.T) {
 func TestNumTurnsInServer(t *testing.T) {
 	turns := 1
 	numAgents := 2
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100000)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100)
 	getTurnsValue := server.GetTurns()
 	if getTurnsValue != turns {
 		t.Error("Incorrect number of turns instantiated, expected:", turns, "got:", getTurnsValue)
@@ -144,7 +144,7 @@ func TestNumTurnsInServer(t *testing.T) {
 
 func TestBroadcastMessage(t *testing.T) {
 	numAgents := 10
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, 10*time.Millisecond, 100000)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, 10*time.Millisecond, 100)
 	agentGoal := int32(numAgents - 1)
 
 	for _, ag := range server.GetAgentMap() {
@@ -162,7 +162,7 @@ func TestBroadcastMessage(t *testing.T) {
 
 func TestSendSynchronousMessage(t *testing.T) {
 	numAgents := 10
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100000)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100)
 	testMessage := testUtils.NewTestAgent(server).CreateTestMessage()
 	for id, ag := range server.GetAgentMap() {
 		ag.SetGoal(1)
@@ -177,7 +177,7 @@ func TestSendSynchronousMessage(t *testing.T) {
 
 func TestSynchronousMessagingSession(t *testing.T) {
 	numAgents := 2
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100000)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100)
 	server.RunSynchronousMessagingSession()
 	for _, ag := range server.GetAgentMap() {
 
@@ -190,7 +190,7 @@ func TestSynchronousMessagingSession(t *testing.T) {
 func TestAccessAgentByID(t *testing.T) {
 	var randNum int32 = 2357
 	numAgents := 2
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100000)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100)
 	for _, ag := range server.GetAgentMap() {
 		ag.SetCounter(randNum)
 	}
@@ -203,7 +203,8 @@ func TestAccessAgentByID(t *testing.T) {
 }
 
 func TestMessagePrint(t *testing.T) {
-	ag := testUtils.NewTestAgent(nil)
+	server := testUtils.GenerateTestServer(1, 1, 1, time.Second, 100)
+	ag := testUtils.NewTestAgent(server)
 	msg := ag.CreateBaseMessage()
 	msg.Print()
 }
@@ -211,7 +212,7 @@ func TestMessagePrint(t *testing.T) {
 func TestGameRunner(t *testing.T) {
 	timeLimit := 100 * time.Millisecond
 	numAgents := 2
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, timeLimit, 100000)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, timeLimit, 100)
 	server.SetGameRunner(server)
 	server.RunTurn(-1, -1)
 	turns := server.TurnCounter
@@ -223,7 +224,7 @@ func TestGameRunner(t *testing.T) {
 func TestIterationRunner(t *testing.T) {
 	timeLimit := 100 * time.Millisecond
 	numAgents := 2
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, timeLimit, 100000)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, timeLimit, 100)
 	server.SetGameRunner(server)
 	server.RunStartOfIteration(-1)
 	server.RunEndOfIteration(-1)
@@ -239,7 +240,7 @@ func TestGoroutineWontHangAsyncMessaging(t *testing.T) {
 	var counter uint32 = 0
 	var numAgents int = 3
 	timeLimit := 1000 * time.Millisecond
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, timeLimit, 100000)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, timeLimit, 100)
 	wg := &sync.WaitGroup{}
 	testUtils.SendNotifyMessages(server.GetAgentMap(), &counter, wg)
 	server.HandleEndOfTurn()
@@ -256,7 +257,7 @@ func TestRepeatedAsyncMessaging(t *testing.T) {
 	var numAgents int = 3
 	var numIters int = 5
 	timeLimit := 100 * time.Millisecond
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, timeLimit, 100000)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, timeLimit, 100)
 	for i := 0; i < numIters; i++ {
 		wg := &sync.WaitGroup{}
 		server.HandleStartOfTurn()
@@ -277,11 +278,13 @@ func TestTimeoutExit(t *testing.T) {
 	var numAgents int = 3
 	timeLimit := 100 * time.Millisecond
 	agentWorkload := 150 * time.Millisecond
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, timeLimit, 100000)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, timeLimit, 100)
 	server.HandleStartOfTurn()
 	timeoutMsg := testUtils.CreateTestTimeoutMessage(agentWorkload)
 	timeoutMsg.SetSender(uuid.New())
-	server.BroadcastMessage(timeoutMsg)
+	for _, ag := range server.GetAgentMap() {
+		ag.BroadcastMessage(timeoutMsg)
+	}
 	status := server.EndAgentListeningSession()
 	if status && (agentWorkload > timeLimit) {
 		t.Error("Should have exited on timeout but did not")
@@ -292,13 +295,15 @@ func TestRepeatedTimeouts(t *testing.T) {
 	var numAgents int = 3
 	var numIters int = 5
 	timeLimit := 100 * time.Millisecond
-	agentWorkload := 50 * time.Millisecond
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, timeLimit, 100000)
+	agentWorkload := 20 * time.Millisecond
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, timeLimit, 100)
 	timeoutMsg := testUtils.CreateTestTimeoutMessage(agentWorkload)
 	timeoutMsg.SetSender(uuid.New())
 	for i := 0; i < numIters; i++ {
 		server.HandleStartOfTurn()
-		server.BroadcastMessage(timeoutMsg)
+		for _, ag := range server.GetAgentMap() {
+			ag.BroadcastMessage(timeoutMsg)
+		}
 		status := server.EndAgentListeningSession()
 		if status && (agentWorkload > timeLimit) {
 
@@ -307,47 +312,21 @@ func TestRepeatedTimeouts(t *testing.T) {
 	}
 }
 
-func TestRecursiveInvokeMessageHandlerCalls(t *testing.T) {
-	numAgents := 3
-	timeLimit := time.Millisecond
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, timeLimit, 100000)
-	msg := testUtils.CreateInfLoopMessage()
-	for _, ag := range server.GetAgentMap() {
-		msg.SetSender(ag.GetID())
-		ag.BroadcastMessage(msg)
-	}
-	server.EndAgentListeningSession()
-}
-
 func TestSendMessageNoIDPanic(t *testing.T) {
 	defer func() {
 		if panicValue := recover(); panicValue == nil {
 			t.Errorf("did not panic when message sender not set")
 		}
 	}()
-	numAgents := 2
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Millisecond, 100000)
+	numAgents := 1
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Millisecond, 100)
 	agMap := server.GetAgentMap()
 
-	for _, ag := range agMap {
+	for _,ag := range agMap {
 		msg := &testUtils.TestMessage{}
 		for recip := range agMap {
 			ag.SendMessage(msg, recip)
 		}
-	}
-}
-
-func TestBroadcastMessageNoIDPanic(t *testing.T) {
-	defer func() {
-		if panicValue := recover(); panicValue == nil {
-			t.Errorf("did not panic when message sender not set")
-		}
-	}()
-	numAgents := 2
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Millisecond, 100000)
-	for _, ag := range server.GetAgentMap() {
-		msg := &testUtils.TestMessage{}
-		ag.BroadcastMessage(msg)
 	}
 }
 
@@ -358,7 +337,7 @@ func TestSendSynchronousMessageNoIDPanic(t *testing.T) {
 		}
 	}()
 	numAgents := 2
-	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Millisecond, 100000)
+	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Millisecond, 100)
 	agMap := server.GetAgentMap()
 	for _, ag := range agMap {
 		msg := &testUtils.TestMessage{}
@@ -375,7 +354,7 @@ func TestRunTurnNotSetPanic(t *testing.T) {
 		}
 	}()
 	server := &testUtils.TestTurnMethodPanics{
-		BaseServer: server.CreateServer[testUtils.ITestBaseAgent](1, 1, time.Millisecond, 100000),
+		BaseServer: server.CreateServer[testUtils.ITestBaseAgent](1, 1, time.Millisecond, 100),
 	}
 	server.RunTurn(0, 0)
 }
@@ -387,7 +366,7 @@ func TestRunStartOfIterationNotSetPanic(t *testing.T) {
 		}
 	}()
 	server := &testUtils.TestTurnMethodPanics{
-		BaseServer: server.CreateServer[testUtils.ITestBaseAgent](1, 1, time.Millisecond, 100000),
+		BaseServer: server.CreateServer[testUtils.ITestBaseAgent](1, 1, time.Millisecond, 100),
 	}
 	server.RunStartOfIteration(0)
 }
@@ -399,7 +378,7 @@ func TestRunEndOfIterationNotSetPanic(t *testing.T) {
 		}
 	}()
 	server := &testUtils.TestTurnMethodPanics{
-		BaseServer: server.CreateServer[testUtils.ITestBaseAgent](1, 1, time.Millisecond, 100000),
+		BaseServer: server.CreateServer[testUtils.ITestBaseAgent](1, 1, time.Millisecond, 100),
 	}
 	server.RunEndOfIteration(0)
 }
@@ -408,7 +387,7 @@ func TestRunStartEndOfTurn(t *testing.T) {
 	timeLimit := 1 * time.Millisecond
 	numAgents := 2
 	iterations := 3
-	server := testUtils.GenerateTestServer(numAgents, iterations, 1, timeLimit, 100000)
+	server := testUtils.GenerateTestServer(numAgents, iterations, 1, timeLimit, 100)
 	server.SetGameRunner(server)
 	server.Start()
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -57,7 +57,7 @@ func TestSendMessage(t *testing.T) {
 	testMessage := agent1.CreateTestMessage()
 	for id, ag := range server.GetAgentMap() {
 		ag.SetGoal(1)
-		server.SendMessage(testMessage, id)
+		server.DeliverMessage(testMessage, id)
 	}
 	server.EndAgentListeningSession()
 	for _, ag := range server.GetAgentMap() {
@@ -166,7 +166,7 @@ func TestSendSynchronousMessage(t *testing.T) {
 	testMessage := testUtils.NewTestAgent(server).CreateTestMessage()
 	for id, ag := range server.GetAgentMap() {
 		ag.SetGoal(1)
-		server.SendSynchronousMessage(testMessage, id)
+		ag.SendSynchronousMessage(testMessage, id)
 	}
 	for _, ag := range server.GetAgentMap() {
 		if !ag.ReceivedMessage() {
@@ -180,9 +180,8 @@ func TestSynchronousMessagingSession(t *testing.T) {
 	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Second, 100)
 	server.RunSynchronousMessagingSession()
 	for _, ag := range server.GetAgentMap() {
-
-		if ag.GetCounter() != int32(numAgents-1) {
-			t.Error("All messages did not pass, got:", ag.GetCounter(), "expected:", numAgents-1)
+		if ag.GetCounter() != int32(numAgents) {
+			t.Error("All messages did not pass, got:", ag.GetCounter(), "expected:", numAgents)
 		}
 	}
 }
@@ -318,7 +317,7 @@ func TestSendMessageNoIDPanic(t *testing.T) {
 			t.Errorf("did not panic when message sender not set")
 		}
 	}()
-	numAgents := 1
+	numAgents := 2
 	server := testUtils.GenerateTestServer(numAgents, 1, 1, time.Millisecond, 100)
 	agMap := server.GetAgentMap()
 


### PR DESCRIPTION
Distributed semaphore to make message limiting more fair; each agent gets its own small limit on bandwidth